### PR TITLE
:bricks: `-plain.jar` 빌드 파일 생성 제한

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,3 +40,7 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+jar {
+	enabled = false
+}


### PR DESCRIPTION
.jar 파일 한 개만 생기게 build.gradle 수정하였습니다.