### PR TITLE
[GOF-157] swagger 적용

### DIFF
--- a/src/main/java/com/forrestgof/jobscanner/common/config/SecurityConfig.java
+++ b/src/main/java/com/forrestgof/jobscanner/common/config/SecurityConfig.java
@@ -28,13 +28,19 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 			"/jobs/**",
 			"/auth/**",
 			"/tags/**",
-			"/swagger-ui/index.html",
-			"/v3/api-docs",
-			"/configuration/ui",
+
+			/* swagger v2 */
+			"/v2/api-docs",
 			"/swagger-resources",
+			"/swagger-resources/**",
+			"/configuration/ui",
 			"/configuration/security",
-			"/webjars/**","/swagger/**",
-			"/swagger-resources/**"
+			"/swagger-ui.html",
+			"/webjars/**",
+
+			/* swagger v3 */
+			"/v3/api-docs/**",
+			"/swagger-ui/**"
 		);
 	}
 


### PR DESCRIPTION
Security ignore 범위에 오류가 있어 swagger가 보여지지 않았던 이슈를 해결했습니다.

Swagger 확인
`/swagger-ui/index.html`