### PR TITLE
[GOF-178] 크롤링 파이프라인 리펙토링

### DIFF
--- a/src/main/java/com/forrestgof/jobscanner/company/domain/Company.java
+++ b/src/main/java/com/forrestgof/jobscanner/company/domain/Company.java
@@ -35,7 +35,7 @@ public class Company extends BaseTimeEntity {
 	private String uniqueKey;           //등록이름+사업자번호
 
 	@Column(unique = true)
-	private String googleName;
+	private String rawName;
 	private String thumbnailUrl;
 
 	@Column(name = "company_name", unique = true)
@@ -64,7 +64,7 @@ public class Company extends BaseTimeEntity {
 		int registrationNumber,
 		LocalDate updatedAt,
 		String uniqueKey,
-		String googleName,
+		String rawName,
 		String thumbnailUrl,
 		String name,
 		LocalDate foundingDate,
@@ -82,7 +82,7 @@ public class Company extends BaseTimeEntity {
 		this.registrationNumber = registrationNumber;
 		this.updatedAt = updatedAt;
 		this.uniqueKey = uniqueKey;
-		this.googleName = googleName;
+		this.rawName = rawName;
 		this.thumbnailUrl = thumbnailUrl;
 		this.name = name;
 		this.foundingDate = foundingDate;
@@ -101,7 +101,7 @@ public class Company extends BaseTimeEntity {
 		this.thumbnailUrl = thumbnailUrl;
 	}
 
-	public void setGoogleName(String googleName) {
-		this.googleName = googleName;
+	public void setRawName(String rawName) {
+		this.rawName = rawName;
 	}
 }

--- a/src/main/java/com/forrestgof/jobscanner/company/repository/CompanyRepository.java
+++ b/src/main/java/com/forrestgof/jobscanner/company/repository/CompanyRepository.java
@@ -8,9 +8,9 @@ import com.forrestgof.jobscanner.company.domain.Company;
 
 public interface CompanyRepository extends JpaRepository<Company, Long> {
 
-	Optional<Company> findByGoogleName(String googleName);
+	Optional<Company> findByRawName(String googleName);
 
 	Optional<Company> findByUniqueKey(String uniqueKey);
 
-	boolean existsByGoogleName(String googleName);
+	boolean existsByRawName(String googleName);
 }

--- a/src/main/java/com/forrestgof/jobscanner/company/service/CompanyService.java
+++ b/src/main/java/com/forrestgof/jobscanner/company/service/CompanyService.java
@@ -3,15 +3,14 @@ package com.forrestgof.jobscanner.company.service;
 import java.util.Optional;
 
 import com.forrestgof.jobscanner.company.domain.Company;
-import com.forrestgof.jobscanner.jobposting.util.dto.GoogleJobDto;
 
 public interface CompanyService {
 
-	Long createFromGoogleJob(GoogleJobDto googleJobDto);
+	Company createFrom(String searchName, String thumbnail);
 
 	Company findOne(Long id);
 
-	Company findByGoogleName(String googleName);
+	Optional<Company> findByRawName(String rawName);
 
 	Optional<Company> getCompanyFromNps(String companyName);
 

--- a/src/main/java/com/forrestgof/jobscanner/jobposting/domain/JobPosting.java
+++ b/src/main/java/com/forrestgof/jobscanner/jobposting/domain/JobPosting.java
@@ -4,7 +4,6 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -52,6 +51,7 @@ public class JobPosting extends BaseTimeEntity {
 
 	private LocalDate postedAt;
 	private LocalDate expiredAt;
+	private boolean isExpired;
 	private String platform;
 
 	@Column(columnDefinition = "TEXT")
@@ -85,6 +85,7 @@ public class JobPosting extends BaseTimeEntity {
 		String location,
 		LocalDate postedAt,
 		LocalDate expiredAt,
+		boolean isExpired,
 		String platform,
 		String applyUrl,
 		JobType type,
@@ -99,6 +100,7 @@ public class JobPosting extends BaseTimeEntity {
 		this.company = company;
 		this.location = location;
 		this.postedAt = postedAt;
+		this.isExpired = isExpired;
 		this.expiredAt = expiredAt;
 		this.platform = platform;
 		this.applyUrl = applyUrl;
@@ -110,16 +112,17 @@ public class JobPosting extends BaseTimeEntity {
 		this.jobDetail = jobDetail;
 	}
 
-	public void setExpiredAt(LocalDate expiredAt) {
+	public void updateFromPlatform(
+		String location,
+		LocalDate expiredAt,
+		JobDetail jobDetail
+	) {
 		this.expiredAt = expiredAt;
-	}
-
-	public void setJobDetail(JobDetail jobDetail) {
 		this.jobDetail = jobDetail;
+		this.location = location;
 	}
 
-	public void setLocation(String location) {
-
-		this.location = location;
+	public void expire() {
+		isExpired = true;
 	}
 }

--- a/src/main/java/com/forrestgof/jobscanner/jobposting/domain/JobType.java
+++ b/src/main/java/com/forrestgof/jobscanner/jobposting/domain/JobType.java
@@ -15,9 +15,9 @@ public enum JobType {
 
 	private final String name;
 
-	public static JobType of(String name) {
+	public static JobType from(String typeNamedKorean) {
 		return Arrays.stream(JobType.values())
-			.filter(r -> r.getName().equals(name))
+			.filter(r -> r.getName().equals(typeNamedKorean))
 			.findFirst()
 			.orElse(null);
 	}

--- a/src/main/java/com/forrestgof/jobscanner/jobposting/util/crawler/BatchUtils.java
+++ b/src/main/java/com/forrestgof/jobscanner/jobposting/util/crawler/BatchUtils.java
@@ -1,14 +1,10 @@
 package com.forrestgof.jobscanner.jobposting.util.crawler;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Predicate;
 
 import org.springframework.stereotype.Component;
 
-import com.forrestgof.jobscanner.jobposting.service.JobPostingService;
 import com.forrestgof.jobscanner.jobposting.util.dto.GoogleCrawlingResponse;
-import com.forrestgof.jobscanner.jobposting.util.dto.GoogleJobDto;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,28 +14,18 @@ public class BatchUtils {
 
 	private final GoogleJobCrawler googleJobCrawler;
 	private final CrawlingDataParser crawlingDataParser;
-	private final JobPostingService jobPostingService;
 
 	public void batchCrawling(List<String> searchKeywords) {
-		for (String searchKeyword : searchKeywords) {
-			int offset = 0;
-			while(true) {
-				GoogleCrawlingResponse googleCrawlingResponse = googleJobCrawler.callCrawler(searchKeyword, offset);
-				if (googleCrawlingResponse.getLength() == 0)
-					break;
-
-				filterNewJob(googleCrawlingResponse)
-					.forEach(crawlingDataParser::saveGoogleJob);
-				offset += 10;
-			}
-		}
+		searchKeywords.forEach(this::search);
 	}
 
-	private List<GoogleJobDto> filterNewJob(GoogleCrawlingResponse googleCrawlingResponse) {
-		List<GoogleJobDto> newJobs = new ArrayList<>();
-		googleCrawlingResponse.getData().stream()
-			.filter(Predicate.not(job -> jobPostingService.existsByGoogleKey(job.key())))
-			.forEach(newJobs::add);
-		return newJobs;
+	private void search(String searchKeyword) {
+		for (int offset=0; true; offset+=10) {
+			GoogleCrawlingResponse googleCrawlingResponse = googleJobCrawler.callCrawler(searchKeyword, offset);
+			if (googleCrawlingResponse.getLength() == 0) {
+				break;
+			}
+			googleCrawlingResponse.getData().forEach(crawlingDataParser::parse);
+		}
 	}
 }

--- a/src/main/java/com/forrestgof/jobscanner/jobposting/util/crawler/CrawlingDataParser.java
+++ b/src/main/java/com/forrestgof/jobscanner/jobposting/util/crawler/CrawlingDataParser.java
@@ -74,7 +74,7 @@ public class CrawlingDataParser {
 
 	private JobPosting parseJobPosting(GoogleJobDto googleJobDto, Company company) {
 		LocalDate postedAt = parsePostedAt(googleJobDto.postedAt());
-		JobType jobType = JobType.of(googleJobDto.type());
+		JobType jobType = JobType.from(googleJobDto.type());
 
 		return JobPosting.builder()
 			.applyUrl(googleJobDto.applyUrl())


### PR DESCRIPTION
- `Company`와 Google 객체 사이의 의존성을 제거하였습니다.
    - 이로 인해 `Company`의 `googleName` 컬럼을 `rawName` 으로 변경하였습니다.
- 동적 크롤링 과정에서 공고 만료시 필드가 달라져 발생하는 예외를 잡아 처리하였습니다.
    - 이로 인해 `JobPosting`에 `isExpired` 컬럼이 추가되었습니다.