### PR TITLE
[GOF-178] :bug: Querydsl 버그 수정 및 옵셔널 코드 리펙토링

### DIFF
--- a/src/main/java/com/forrestgof/jobscanner/jobposting/repository/JobPostingRepositoryImpl.java
+++ b/src/main/java/com/forrestgof/jobscanner/jobposting/repository/JobPostingRepositoryImpl.java
@@ -32,11 +32,10 @@ public class JobPostingRepositoryImpl implements JobPostingRepositoryCustom {
 	public List<JobPosting> findFilterJobs(JobSearchCondition condition) {
 		JPAQuery<JobPosting> query = createQueryByCondition(condition);
 
-		Optional<SortingCondition> optionalSortingCondition = condition.getSortingCondition();
-		if (optionalSortingCondition.isPresent())
-			query = orderBy(query, optionalSortingCondition.get());
-
-		return query.fetch();
+		return condition.getSortingCondition()
+			.map(sortingCondition -> orderBy(query, sortingCondition))
+			.orElse(query)
+			.fetch();
 	}
 
 	private JPAQuery<JobPosting> createQueryByCondition(JobSearchCondition condition) {
@@ -57,7 +56,7 @@ public class JobPostingRepositoryImpl implements JobPostingRepositoryCustom {
 	}
 
 	private BooleanExpression notExpired() {
-		return jobPosting.isExpired.not();
+		return jobPosting.isExpired.eq(false);
 	}
 
 	private BooleanExpression employeesGoe(long employees) {


### PR DESCRIPTION
- Querydsl에서 버그가 발생하여 만료여부를 확인하는 로직에 `.not`  대신 `.eq(false)`을 적용하였습니다.
- 정렬 조건에서 Optional이 사용되는데 Optional에서 제공하는 map 메서드를 활용하여 리펙토링을 진행하였습니다.