### PR TITLE
[GOF-174] 온보딩 데이터 조회 로직 작성하였습니다.

### DIFF
--- a/src/main/java/com/forrestgof/jobscanner/duty/domain/MemberDuty.java
+++ b/src/main/java/com/forrestgof/jobscanner/duty/domain/MemberDuty.java
@@ -1,4 +1,4 @@
-package com.forrestgof.jobscanner.member.domain;
+package com.forrestgof.jobscanner.duty.domain;
 
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -8,7 +8,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
 import com.forrestgof.jobscanner.common.entity.BaseTimeEntity;
-import com.forrestgof.jobscanner.duty.domain.Duty;
+import com.forrestgof.jobscanner.member.domain.Member;
 
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/com/forrestgof/jobscanner/duty/repository/DutyRepository.java
+++ b/src/main/java/com/forrestgof/jobscanner/duty/repository/DutyRepository.java
@@ -1,0 +1,8 @@
+package com.forrestgof.jobscanner.duty.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.forrestgof.jobscanner.duty.domain.Duty;
+
+public interface DutyRepository extends JpaRepository<Duty, Long> {
+}

--- a/src/main/java/com/forrestgof/jobscanner/duty/repository/MemberDutyRepository.java
+++ b/src/main/java/com/forrestgof/jobscanner/duty/repository/MemberDutyRepository.java
@@ -1,0 +1,13 @@
+package com.forrestgof.jobscanner.duty.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.forrestgof.jobscanner.duty.domain.MemberDuty;
+import com.forrestgof.jobscanner.member.domain.Member;
+
+public interface MemberDutyRepository extends JpaRepository<MemberDuty, Long> {
+
+	List<MemberDuty> findByMember(Member member);
+}

--- a/src/main/java/com/forrestgof/jobscanner/duty/service/MemberDutyService.java
+++ b/src/main/java/com/forrestgof/jobscanner/duty/service/MemberDutyService.java
@@ -1,0 +1,28 @@
+package com.forrestgof.jobscanner.duty.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.forrestgof.jobscanner.duty.domain.Duty;
+import com.forrestgof.jobscanner.duty.domain.MemberDuty;
+import com.forrestgof.jobscanner.duty.repository.MemberDutyRepository;
+import com.forrestgof.jobscanner.member.domain.Member;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberDutyService {
+
+	private final MemberDutyRepository memberDutyRepository;
+
+	public List<Duty> findDutiesFromMember(Member member) {
+		List<MemberDuty> memberDuties = memberDutyRepository.findByMember(member);
+
+		return memberDuties.stream()
+			.map(MemberDuty::getDuty)
+			.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/forrestgof/jobscanner/jobposting/controller/TagApiController.java
+++ b/src/main/java/com/forrestgof/jobscanner/jobposting/controller/TagApiController.java
@@ -10,8 +10,8 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.forrestgof.jobscanner.common.util.CustomResponse;
-import com.forrestgof.jobscanner.jobposting.domain.Tag;
-import com.forrestgof.jobscanner.jobposting.service.TagService;
+import com.forrestgof.jobscanner.tag.domain.Tag;
+import com.forrestgof.jobscanner.tag.service.TagService;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/forrestgof/jobscanner/jobposting/controller/dto/JobDto.java
+++ b/src/main/java/com/forrestgof/jobscanner/jobposting/controller/dto/JobDto.java
@@ -4,8 +4,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.forrestgof.jobscanner.jobposting.domain.JobPosting;
-import com.forrestgof.jobscanner.jobposting.domain.JobTag;
-import com.forrestgof.jobscanner.jobposting.domain.Tag;
+import com.forrestgof.jobscanner.tag.domain.JobTag;
+import com.forrestgof.jobscanner.tag.domain.Tag;
 
 import lombok.Data;
 

--- a/src/main/java/com/forrestgof/jobscanner/jobposting/controller/dto/JobPreviewDto.java
+++ b/src/main/java/com/forrestgof/jobscanner/jobposting/controller/dto/JobPreviewDto.java
@@ -4,8 +4,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.forrestgof.jobscanner.jobposting.domain.JobPosting;
-import com.forrestgof.jobscanner.jobposting.domain.JobTag;
-import com.forrestgof.jobscanner.jobposting.domain.Tag;
+import com.forrestgof.jobscanner.tag.domain.JobTag;
+import com.forrestgof.jobscanner.tag.domain.Tag;
 
 import lombok.Data;
 

--- a/src/main/java/com/forrestgof/jobscanner/jobposting/domain/JobPosting.java
+++ b/src/main/java/com/forrestgof/jobscanner/jobposting/domain/JobPosting.java
@@ -19,6 +19,7 @@ import javax.persistence.Table;
 
 import com.forrestgof.jobscanner.common.entity.BaseTimeEntity;
 import com.forrestgof.jobscanner.company.domain.Company;
+import com.forrestgof.jobscanner.tag.domain.JobTag;
 
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/src/main/java/com/forrestgof/jobscanner/jobposting/repository/JobPostingRepositoryImpl.java
+++ b/src/main/java/com/forrestgof/jobscanner/jobposting/repository/JobPostingRepositoryImpl.java
@@ -2,12 +2,11 @@ package com.forrestgof.jobscanner.jobposting.repository;
 
 import static com.forrestgof.jobscanner.company.domain.QCompany.*;
 import static com.forrestgof.jobscanner.jobposting.domain.QJobPosting.*;
-import static com.forrestgof.jobscanner.jobposting.domain.QJobTag.*;
-import static com.forrestgof.jobscanner.jobposting.domain.QTag.*;
+import static com.forrestgof.jobscanner.tag.domain.QJobTag.*;
+import static com.forrestgof.jobscanner.tag.domain.QTag.*;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 import javax.persistence.EntityManager;
 

--- a/src/main/java/com/forrestgof/jobscanner/jobposting/repository/MemberTagRepository.java
+++ b/src/main/java/com/forrestgof/jobscanner/jobposting/repository/MemberTagRepository.java
@@ -1,0 +1,14 @@
+package com.forrestgof.jobscanner.tag.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.forrestgof.jobscanner.member.domain.Member;
+import com.forrestgof.jobscanner.tag.domain.MemberTag;
+
+public interface MemberTagRepository extends JpaRepository<MemberTag, Long> {
+
+	List<MemberTag> findByMember(Member member);
+}
+

--- a/src/main/java/com/forrestgof/jobscanner/jobposting/service/MemberTagService.java
+++ b/src/main/java/com/forrestgof/jobscanner/jobposting/service/MemberTagService.java
@@ -1,0 +1,28 @@
+package com.forrestgof.jobscanner.tag.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.forrestgof.jobscanner.member.domain.Member;
+import com.forrestgof.jobscanner.tag.domain.MemberTag;
+import com.forrestgof.jobscanner.tag.domain.Tag;
+import com.forrestgof.jobscanner.tag.repository.MemberTagRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberTagService {
+
+	private final MemberTagRepository memberTagRepository;
+
+	public List<Tag> findTagsFromMember(Member member) {
+		List<MemberTag> memberTags = memberTagRepository.findByMember(member);
+
+		return memberTags.stream()
+			.map(MemberTag::getTag)
+			.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/forrestgof/jobscanner/jobposting/util/crawler/CrawlingDataParser.java
+++ b/src/main/java/com/forrestgof/jobscanner/jobposting/util/crawler/CrawlingDataParser.java
@@ -14,12 +14,12 @@ import com.forrestgof.jobscanner.company.domain.Company;
 import com.forrestgof.jobscanner.company.service.CompanyService;
 import com.forrestgof.jobscanner.jobposting.domain.JobDetail;
 import com.forrestgof.jobscanner.jobposting.domain.JobPosting;
-import com.forrestgof.jobscanner.jobposting.domain.JobTag;
+import com.forrestgof.jobscanner.tag.domain.JobTag;
 import com.forrestgof.jobscanner.jobposting.domain.JobType;
-import com.forrestgof.jobscanner.jobposting.domain.Tag;
+import com.forrestgof.jobscanner.tag.domain.Tag;
 import com.forrestgof.jobscanner.jobposting.service.JobPostingService;
-import com.forrestgof.jobscanner.jobposting.service.JobTagService;
-import com.forrestgof.jobscanner.jobposting.service.TagService;
+import com.forrestgof.jobscanner.tag.service.JobTagService;
+import com.forrestgof.jobscanner.tag.service.TagService;
 import com.forrestgof.jobscanner.jobposting.util.dto.GoogleJobDto;
 import com.forrestgof.jobscanner.jobposting.util.dto.PlatformJobDto;
 

--- a/src/main/java/com/forrestgof/jobscanner/member/controller/MemberApiController.java
+++ b/src/main/java/com/forrestgof/jobscanner/member/controller/MemberApiController.java
@@ -1,0 +1,55 @@
+package com.forrestgof.jobscanner.member.controller;
+
+import java.util.List;
+import java.util.Optional;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.forrestgof.jobscanner.auth.jwt.JwtHeaderUtil;
+import com.forrestgof.jobscanner.auth.service.AuthService;
+import com.forrestgof.jobscanner.common.util.CustomResponse;
+import com.forrestgof.jobscanner.duty.domain.Duty;
+import com.forrestgof.jobscanner.duty.service.MemberDutyService;
+import com.forrestgof.jobscanner.member.controller.dto.MemberResponse;
+import com.forrestgof.jobscanner.member.domain.Member;
+import com.forrestgof.jobscanner.member.domain.ObjectiveCompany;
+import com.forrestgof.jobscanner.member.service.MemberService;
+import com.forrestgof.jobscanner.member.service.ObjectiveCompanyService;
+import com.forrestgof.jobscanner.tag.domain.Tag;
+import com.forrestgof.jobscanner.tag.service.MemberTagService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/members")
+@RequiredArgsConstructor
+public class MemberApiController {
+
+	private final AuthService authService;
+	private final MemberTagService memberTagService;
+	private final MemberDutyService memberDutyService;
+	private final ObjectiveCompanyService objectiveCompanyService;
+
+	@GetMapping("")
+	public ResponseEntity<MemberResponse> getMember(HttpServletRequest request) {
+		String appToken = JwtHeaderUtil.getAccessToken(request);
+
+		Member member = authService.getMemberFromAppToken(appToken);
+		List<Tag> tags = memberTagService.findTagsFromMember(member);
+		List<Duty> duties = memberDutyService.findDutiesFromMember(member);
+		Optional<ObjectiveCompany> objectiveCompany = objectiveCompanyService.findByMember(member);
+
+		MemberResponse memberResponse = new MemberResponse();
+		memberResponse.updateMember(member);
+		memberResponse.updateTags(tags);
+		memberResponse.updateDuties(duties);
+		objectiveCompany.ifPresent(memberResponse::updateObjectiveCompany);
+
+		return CustomResponse.success(memberResponse);
+	}
+}

--- a/src/main/java/com/forrestgof/jobscanner/member/controller/dto/MemberResponse.java
+++ b/src/main/java/com/forrestgof/jobscanner/member/controller/dto/MemberResponse.java
@@ -1,0 +1,54 @@
+package com.forrestgof.jobscanner.member.controller.dto;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.forrestgof.jobscanner.duty.domain.Duty;
+import com.forrestgof.jobscanner.member.domain.Member;
+import com.forrestgof.jobscanner.member.domain.ObjectiveCompany;
+import com.forrestgof.jobscanner.tag.domain.Tag;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberResponse {
+
+	private String email;
+	private String password;
+	private String nickname;
+	private String imageUrl;
+
+	private List<String> tags;
+	private List<String> duties;
+
+	private int objectiveEmployeeCount;
+	private long objectiveSalary;
+
+	public void updateMember(Member member) {
+		this.email = member.getEmail();
+		this.password = member.getPassword();
+		this.nickname = member.getNickname();
+		this.imageUrl = member.getImageUrl();
+	}
+
+	public void updateTags(List<Tag> tags) {
+		this.tags = tags.stream()
+			.map(Tag::getName)
+			.collect(Collectors.toList());
+	}
+
+	public void updateDuties(List<Duty> duties) {
+		this.duties = duties.stream()
+			.map(Duty::getName)
+			.collect(Collectors.toList());
+	}
+
+	public void updateObjectiveCompany(ObjectiveCompany objectiveCompany) {
+		this.objectiveEmployeeCount = objectiveCompany.getEmployeeCount();
+		this.objectiveSalary = objectiveCompany.getSalary();
+	}
+}

--- a/src/main/java/com/forrestgof/jobscanner/member/repository/ObjectiveCompanyRepository.java
+++ b/src/main/java/com/forrestgof/jobscanner/member/repository/ObjectiveCompanyRepository.java
@@ -1,0 +1,8 @@
+package com.forrestgof.jobscanner.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.forrestgof.jobscanner.member.domain.ObjectiveCompany;
+
+public interface ObjectiveCompanyRepository extends JpaRepository<ObjectiveCompany, Long> {
+}

--- a/src/main/java/com/forrestgof/jobscanner/member/service/ObjectiveCompanyService.java
+++ b/src/main/java/com/forrestgof/jobscanner/member/service/ObjectiveCompanyService.java
@@ -1,0 +1,22 @@
+package com.forrestgof.jobscanner.member.service;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import com.forrestgof.jobscanner.member.domain.Member;
+import com.forrestgof.jobscanner.member.domain.ObjectiveCompany;
+import com.forrestgof.jobscanner.member.repository.ObjectiveCompanyRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ObjectiveCompanyService {
+
+	private final ObjectiveCompanyRepository objectiveCompanyRepository;
+
+	public Optional<ObjectiveCompany> findByMember(Member member) {
+		return objectiveCompanyRepository.findById(member.getId());
+	}
+}

--- a/src/main/java/com/forrestgof/jobscanner/tag/domain/JobTag.java
+++ b/src/main/java/com/forrestgof/jobscanner/tag/domain/JobTag.java
@@ -1,4 +1,4 @@
-package com.forrestgof.jobscanner.jobposting.domain;
+package com.forrestgof.jobscanner.tag.domain;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -9,6 +9,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
 import com.forrestgof.jobscanner.common.entity.BaseTimeEntity;
+import com.forrestgof.jobscanner.jobposting.domain.JobPosting;
 
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/com/forrestgof/jobscanner/tag/domain/MemberTag.java
+++ b/src/main/java/com/forrestgof/jobscanner/tag/domain/MemberTag.java
@@ -1,4 +1,4 @@
-package com.forrestgof.jobscanner.member.domain;
+package com.forrestgof.jobscanner.tag.domain;
 
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -8,7 +8,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
 import com.forrestgof.jobscanner.common.entity.BaseTimeEntity;
-import com.forrestgof.jobscanner.jobposting.domain.Tag;
+import com.forrestgof.jobscanner.member.domain.Member;
 
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/com/forrestgof/jobscanner/tag/domain/Tag.java
+++ b/src/main/java/com/forrestgof/jobscanner/tag/domain/Tag.java
@@ -1,4 +1,4 @@
-package com.forrestgof.jobscanner.jobposting.domain;
+package com.forrestgof.jobscanner.tag.domain;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/src/main/java/com/forrestgof/jobscanner/tag/repository/JobTagRepository.java
+++ b/src/main/java/com/forrestgof/jobscanner/tag/repository/JobTagRepository.java
@@ -1,8 +1,8 @@
-package com.forrestgof.jobscanner.jobposting.repository;
+package com.forrestgof.jobscanner.tag.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.forrestgof.jobscanner.jobposting.domain.JobTag;
+import com.forrestgof.jobscanner.tag.domain.JobTag;
 
 public interface JobTagRepository extends JpaRepository<JobTag, Long> {
 }

--- a/src/main/java/com/forrestgof/jobscanner/tag/repository/TagRepository.java
+++ b/src/main/java/com/forrestgof/jobscanner/tag/repository/TagRepository.java
@@ -1,10 +1,10 @@
-package com.forrestgof.jobscanner.jobposting.repository;
+package com.forrestgof.jobscanner.tag.repository;
 
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.forrestgof.jobscanner.jobposting.domain.Tag;
+import com.forrestgof.jobscanner.tag.domain.Tag;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
 

--- a/src/main/java/com/forrestgof/jobscanner/tag/service/JobTagService.java
+++ b/src/main/java/com/forrestgof/jobscanner/tag/service/JobTagService.java
@@ -1,10 +1,10 @@
-package com.forrestgof.jobscanner.jobposting.service;
+package com.forrestgof.jobscanner.tag.service;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.forrestgof.jobscanner.jobposting.domain.JobTag;
-import com.forrestgof.jobscanner.jobposting.repository.JobTagRepository;
+import com.forrestgof.jobscanner.tag.domain.JobTag;
+import com.forrestgof.jobscanner.tag.repository.JobTagRepository;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/forrestgof/jobscanner/tag/service/TagService.java
+++ b/src/main/java/com/forrestgof/jobscanner/tag/service/TagService.java
@@ -1,12 +1,12 @@
-package com.forrestgof.jobscanner.jobposting.service;
+package com.forrestgof.jobscanner.tag.service;
 
 import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.forrestgof.jobscanner.jobposting.domain.Tag;
-import com.forrestgof.jobscanner.jobposting.repository.TagRepository;
+import com.forrestgof.jobscanner.tag.domain.Tag;
+import com.forrestgof.jobscanner.tag.repository.TagRepository;
 
 import lombok.RequiredArgsConstructor;
 


### PR DESCRIPTION
### 변경 사항
- Tag 패키지를 JobPosting에서 별도의 도메인 패키지로 분리하였습니다.
- MemberTagService, MemberDutyService 등 다대다 관계에서 별도의 서비스 계층을 두어야 되는지 고민이 되었는데 아래 레퍼런스를 참고하여 별도로 관리하기로 결정하였습니다.
    - https://www.inflearn.com/questions/37062

### 고민 사항
- 현재 MemberApiController에서 각각의 서비스를 호출하여 DTO를 조립하여 반환하는데, 이러한 로직을 MemberService에 넣을까 고민중입니다. (Service에서 DTO를 반환)
- 온보딩 데이터 조회 API와 기본 Member 정보 조회 API를 분리해야 할지 고민입니다.