### PR TITLE
예외 처리 방법 리팩토링 했습니다.

### DIFF
--- a/src/main/java/com/forrestgof/jobscanner/auth/exception/AuthException.java
+++ b/src/main/java/com/forrestgof/jobscanner/auth/exception/AuthException.java
@@ -1,0 +1,15 @@
+package com.forrestgof.jobscanner.auth.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AuthException extends RuntimeException {
+
+	public AuthException() {
+		super();
+	}
+
+	public AuthException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/forrestgof/jobscanner/auth/jwt/AuthToken.java
+++ b/src/main/java/com/forrestgof/jobscanner/auth/jwt/AuthToken.java
@@ -4,8 +4,7 @@ import java.security.Key;
 import java.util.Date;
 
 import com.forrestgof.jobscanner.auth.RoleType;
-import com.forrestgof.jobscanner.common.exception.CustomException;
-import com.forrestgof.jobscanner.common.exception.ErrorCode;
+import com.forrestgof.jobscanner.auth.exception.AuthException;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -68,7 +67,7 @@ public class AuthToken {
 		} catch (ExpiredJwtException e) {
 			return e.getClaims();
 		} catch (SecurityException | JwtException | IllegalArgumentException e) {
-			throw new CustomException(ErrorCode.INVALID_TOKEN_EXCEPTION);
+			throw new AuthException(e.getMessage());
 		}
 	}
 
@@ -84,7 +83,7 @@ public class AuthToken {
 				.parseClaimsJws(token)
 				.getBody();
 		} catch (SecurityException | JwtException | IllegalArgumentException e) {
-			throw new CustomException(ErrorCode.INVALID_TOKEN_EXCEPTION);
+			throw new AuthException(e.getMessage());
 		}
 	}
 }

--- a/src/main/java/com/forrestgof/jobscanner/auth/jwt/JwtHeaderUtil.java
+++ b/src/main/java/com/forrestgof/jobscanner/auth/jwt/JwtHeaderUtil.java
@@ -1,9 +1,10 @@
 package com.forrestgof.jobscanner.auth.jwt;
 
+import java.util.Optional;
+
 import javax.servlet.http.HttpServletRequest;
 
-import com.forrestgof.jobscanner.common.exception.CustomException;
-import com.forrestgof.jobscanner.common.exception.ErrorCode;
+import com.forrestgof.jobscanner.auth.exception.AuthException;
 
 public class JwtHeaderUtil {
 
@@ -13,26 +14,22 @@ public class JwtHeaderUtil {
 	private final static String CODE = "code";
 
 	public static String getCode(HttpServletRequest request) {
-		if (request.getHeader(CODE) == null) {
-			throw new CustomException(ErrorCode.INVALID_TOKEN_EXCEPTION);
-		}
-		return request.getHeader(CODE);
+		return Optional.ofNullable(request.getHeader(CODE))
+			.orElseThrow(() -> new AuthException("The header does not contain code"));
 	}
 
 	public static String getAccessToken(HttpServletRequest request) {
 		String headerValue = request.getHeader(HEADER_AUTHORIZATION);
 
 		if (headerValue == null || !headerValue.startsWith(TOKEN_PREFIX)) {
-			throw new CustomException(ErrorCode.INVALID_TOKEN_EXCEPTION);
+			throw new AuthException("The header does not contain app token or has an invalid format");
 		}
 
 		return headerValue.substring(TOKEN_PREFIX.length());
 	}
 
 	public static String getRefreshToken(HttpServletRequest request) {
-		if (request.getHeader(HEADER_REFRESH_TOKEN) == null) {
-			throw new CustomException(ErrorCode.INVALID_TOKEN_EXCEPTION);
-		}
-		return request.getHeader(HEADER_REFRESH_TOKEN);
+		return Optional.ofNullable(request.getHeader(HEADER_REFRESH_TOKEN))
+			.orElseThrow(() -> new AuthException("The header does not contain refresh token"));
 	}
 }

--- a/src/main/java/com/forrestgof/jobscanner/auth/service/DefaultAuthService.java
+++ b/src/main/java/com/forrestgof/jobscanner/auth/service/DefaultAuthService.java
@@ -6,10 +6,9 @@ import org.springframework.stereotype.Service;
 
 import com.forrestgof.jobscanner.auth.dto.AuthRefreshResponse;
 import com.forrestgof.jobscanner.auth.dto.AuthTokenResponse;
+import com.forrestgof.jobscanner.auth.exception.AuthException;
 import com.forrestgof.jobscanner.auth.jwt.AuthToken;
 import com.forrestgof.jobscanner.auth.jwt.AuthTokenProvider;
-import com.forrestgof.jobscanner.common.exception.CustomException;
-import com.forrestgof.jobscanner.common.exception.ErrorCode;
 import com.forrestgof.jobscanner.mail.service.MailService;
 import com.forrestgof.jobscanner.member.domain.Member;
 import com.forrestgof.jobscanner.session.domain.Session;
@@ -56,7 +55,7 @@ public class DefaultAuthService implements AuthService {
 	public void validateMailWithAppToken(String email, String appToken) {
 		Member findMember = getMemberFromAppToken(appToken);
 		if (!email.equals(findMember.getEmail())) {
-			throw new CustomException(ErrorCode.INVALID_TOKEN_EXCEPTION);
+			throw new AuthException("Invalid email authentication");
 		}
 	}
 
@@ -112,7 +111,7 @@ public class DefaultAuthService implements AuthService {
 		String refreshTokenUuid = refreshClaims.get("jti", String.class);
 
 		if (!sessionService.existsByAppTokenUuidAndRefreshTokenUuid(appTokenUuid, refreshTokenUuid)) {
-			throw new CustomException(ErrorCode.INVALID_TOKEN_EXCEPTION);
+			throw new AuthException("Unissued app token or refresh token");
 		}
 	}
 

--- a/src/main/java/com/forrestgof/jobscanner/auth/social/GoogleTokenValidator.java
+++ b/src/main/java/com/forrestgof/jobscanner/auth/social/GoogleTokenValidator.java
@@ -1,6 +1,7 @@
 package com.forrestgof.jobscanner.auth.social;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -9,11 +10,10 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import com.forrestgof.jobscanner.auth.exception.AuthException;
 import com.forrestgof.jobscanner.auth.social.dto.GoogleOAuthResponse;
 import com.forrestgof.jobscanner.auth.social.dto.GoogleUserResponse;
 import com.forrestgof.jobscanner.common.config.properties.AuthProperties;
-import com.forrestgof.jobscanner.common.exception.CustomException;
-import com.forrestgof.jobscanner.common.exception.ErrorCode;
 import com.forrestgof.jobscanner.member.domain.Member;
 
 import reactor.core.publisher.Mono;
@@ -48,11 +48,14 @@ public class GoogleTokenValidator implements SocialTokenValidator {
 				.accept(MediaType.APPLICATION_JSON)
 				.bodyValue(tokenRequest(code))
 				.retrieve()
-				.onStatus(HttpStatus::is4xxClientError, response
-					-> Mono.error(
-					new CustomException("Social Access Token is unauthorized", ErrorCode.INVALID_TOKEN_EXCEPTION)))
-				.onStatus(HttpStatus::is5xxServerError, response
-					-> Mono.error(new CustomException("Internal Server Error", ErrorCode.INVALID_TOKEN_EXCEPTION)))
+				.onStatus(
+					HttpStatus::is4xxClientError,
+					response
+						-> Mono.error(new AuthException("Failed to get google token with code")))
+				.onStatus(
+					HttpStatus::is5xxServerError,
+					response
+						-> Mono.error(new AuthException("Failed to get google token with code")))
 				.bodyToMono(GoogleOAuthResponse.class)
 				.block())
 			.getIdToken();
@@ -77,22 +80,23 @@ public class GoogleTokenValidator implements SocialTokenValidator {
 			.onStatus(
 				HttpStatus::is4xxClientError,
 				response
-					-> Mono.error(new CustomException(ErrorCode.INVALID_TOKEN_EXCEPTION)))
+					-> Mono.error(new AuthException("Failed to get google user information with token")))
 			.onStatus(
 				HttpStatus::is5xxServerError,
 				response
-					-> Mono.error(new CustomException(ErrorCode.INVALID_TOKEN_EXCEPTION)))
+					-> Mono.error(new AuthException("Failed to get google user information with token")))
 			.bodyToMono(GoogleUserResponse.class)
 			.block();
 	}
 
 	private Member generateMemberFromGoogleUser(GoogleUserResponse googleUserResponse) {
-		String email = googleUserResponse.getEmail();
-		String nickname = googleUserResponse.getName();
+		String email = Optional.ofNullable(googleUserResponse.getEmail())
+			.orElseThrow(() -> new AuthException("Google email information is missing"));
+
+		String nickname = Optional.ofNullable(googleUserResponse.getName())
+			.orElseThrow(() -> new AuthException("Google nickname information is missing"));
+
 		String imageUrl = googleUserResponse.getPicture();
-		if (email == null || nickname == null) {
-			throw new CustomException(ErrorCode.INVALID_TOKEN_EXCEPTION);
-		}
 
 		return Member.builder()
 			.email(email)

--- a/src/main/java/com/forrestgof/jobscanner/common/exception/ErrorCode.java
+++ b/src/main/java/com/forrestgof/jobscanner/common/exception/ErrorCode.java
@@ -15,10 +15,6 @@ public enum ErrorCode {
 	EXPIRED_CODE(HttpStatus.valueOf(400), "Expired Code"),
 	UNEXPECTED_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "Unexpected exception"),
 
-	//AUTH
-	INVALID_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "Invalid token"),
-	UNSUPPORTED_SOCIAL_TYPE_EXCEPTION(HttpStatus.BAD_REQUEST, "Unsupported Social Type"),
-
 	// MEMBER
 	NOT_FOUND_MEMBER(HttpStatus.UNAUTHORIZED, "Unsigned account"),
 	ALREADY_EXIST_MEMBER(HttpStatus.CONFLICT, "Already joined member"),

--- a/src/main/java/com/forrestgof/jobscanner/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/forrestgof/jobscanner/common/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com.forrestgof.jobscanner.auth.exception.AuthException;
 import com.forrestgof.jobscanner.common.util.CustomResponse;
 
 import lombok.extern.log4j.Log4j2;
@@ -12,21 +13,31 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public class GlobalExceptionHandler {
 
+	@ExceptionHandler(AuthException.class)
+	public ResponseEntity authExceptionHandler(AuthException e) {
+		log.error(e);
+		e.printStackTrace();
+		return CustomResponse.error("AuthException: " + e.getMessage());
+	}
+
 	@ExceptionHandler(CustomException.class)
 	public ResponseEntity customExceptionHandle(CustomException e) {
 		log.error(e);
+		e.printStackTrace();
 		return CustomResponse.error(e.getErrorCode());
 	}
 
 	@ExceptionHandler(UndefinedException.class)
 	public ResponseEntity undefinedExceptionHandle(UndefinedException e) {
 		log.error(e);
+		e.printStackTrace();
 		return CustomResponse.error(e.getMessage());
 	}
 
 	@ExceptionHandler
 	public ResponseEntity unexpectedExceptionHandle(Exception e) {
 		log.error(e);
+		e.printStackTrace();
 		return CustomResponse.error(ErrorCode.UNEXPECTED_EXCEPTION);
 	}
 }

--- a/src/main/java/com/forrestgof/jobscanner/session/service/DefaultSessionService.java
+++ b/src/main/java/com/forrestgof/jobscanner/session/service/DefaultSessionService.java
@@ -3,8 +3,7 @@ package com.forrestgof.jobscanner.session.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.forrestgof.jobscanner.common.exception.CustomException;
-import com.forrestgof.jobscanner.common.exception.ErrorCode;
+import com.forrestgof.jobscanner.auth.exception.AuthException;
 import com.forrestgof.jobscanner.member.domain.Member;
 import com.forrestgof.jobscanner.session.domain.Session;
 import com.forrestgof.jobscanner.session.repository.SessionRepository;
@@ -29,7 +28,7 @@ public class DefaultSessionService implements SessionService {
 	@Override
 	public Session findByAppTokenUuid(String appTokenUuid) {
 		return sessionRepository.findByAppTokenUuid(appTokenUuid)
-			.orElseThrow(() -> new CustomException(ErrorCode.INVALID_TOKEN_EXCEPTION));
+			.orElseThrow(() -> new AuthException("Unissued app token"));
 	}
 
 	@Override

--- a/src/main/java/com/forrestgof/jobscanner/socialmember/domain/SocialType.java
+++ b/src/main/java/com/forrestgof/jobscanner/socialmember/domain/SocialType.java
@@ -3,8 +3,7 @@ package com.forrestgof.jobscanner.socialmember.domain;
 import java.util.Arrays;
 import java.util.Locale;
 
-import com.forrestgof.jobscanner.common.exception.CustomException;
-import com.forrestgof.jobscanner.common.exception.ErrorCode;
+import com.forrestgof.jobscanner.auth.exception.AuthException;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -21,6 +20,6 @@ public enum SocialType {
 		return Arrays.stream(SocialType.values())
 			.filter((socialType -> socialType.name().toLowerCase(Locale.ROOT).equals(inputType)))
 			.findFirst()
-			.orElseThrow(() -> new CustomException(ErrorCode.UNSUPPORTED_SOCIAL_TYPE_EXCEPTION));
+			.orElseThrow(() -> new AuthException("Unsupported Social Type"));
 	}
 }


### PR DESCRIPTION
- 기존 Enum을 사용한 CustomException은 메세지를 세분화할 수 없다는 문제가 있었습니다. 그래서 각 도메인별로 Exception 객체를 만들고 메세지를 입력하는 방법으로 개선했습니다.
- 예외 핸들링할 때 어디서 예외가 터지는지 로그가 남지 않아 디버깅할 때 불편하다는 문제가 있었습니다. 그래서 예외 핸들링할 때 e.printStackTrace()를 추가했습니다.