### PR TITLE
[GOF-203] 직무 조회 API 개발

### DIFF
--- a/src/main/java/com/forrestgof/jobscanner/duty/controller/DutyApiController.java
+++ b/src/main/java/com/forrestgof/jobscanner/duty/controller/DutyApiController.java
@@ -1,0 +1,32 @@
+package com.forrestgof.jobscanner.duty.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.forrestgof.jobscanner.common.dto.CustomResponse;
+import com.forrestgof.jobscanner.duty.domain.Duty;
+import com.forrestgof.jobscanner.duty.service.DutyService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("duties")
+@RequiredArgsConstructor
+public class DutyApiController {
+
+	private final DutyService dutyService;
+
+	@GetMapping
+	public ResponseEntity<CustomResponse> getDuties() {
+		List<String> duties = dutyService.findAll()
+			.stream()
+			.map(Duty::getName)
+			.toList();
+
+		return CustomResponse.success(duties);
+	}
+}

--- a/src/main/java/com/forrestgof/jobscanner/duty/service/DutyService.java
+++ b/src/main/java/com/forrestgof/jobscanner/duty/service/DutyService.java
@@ -1,0 +1,23 @@
+package com.forrestgof.jobscanner.duty.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.forrestgof.jobscanner.duty.domain.Duty;
+import com.forrestgof.jobscanner.duty.repository.DutyRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DutyService {
+
+	private final DutyRepository dutyRepository;
+
+	public List<Duty> findAll() {
+		return dutyRepository.findAll();
+	}
+}

--- a/src/main/java/com/forrestgof/jobscanner/member/domain/Member.java
+++ b/src/main/java/com/forrestgof/jobscanner/member/domain/Member.java
@@ -66,7 +66,7 @@ public class Member extends BaseTimeEntity {
 
 	public void updateMember(
 		@NotNull String nickname,
-		@NotNull String imageUrl
+		String imageUrl
 	) {
 		this.nickname = nickname;
 		this.imageUrl = imageUrl;

--- a/src/main/java/com/forrestgof/jobscanner/tag/controller/TagApiController.java
+++ b/src/main/java/com/forrestgof/jobscanner/tag/controller/TagApiController.java
@@ -23,10 +23,9 @@ public class TagApiController {
 	private final TagService tagService;
 
 	@GetMapping
-	@ResponseBody
 	public ResponseEntity<CustomResponse> getTags() {
-		List<Tag> all = tagService.findAll();
-		List<String> tags = all.stream()
+		List<String> tags = tagService.findAll()
+			.stream()
 			.map(Tag::getName)
 			.collect(Collectors.toList());
 

--- a/src/main/java/com/forrestgof/jobscanner/tag/controller/TagApiController.java
+++ b/src/main/java/com/forrestgof/jobscanner/tag/controller/TagApiController.java
@@ -1,4 +1,4 @@
-package com.forrestgof.jobscanner.jobposting.controller;
+package com.forrestgof.jobscanner.tag.controller;
 
 import java.util.List;
 import java.util.stream.Collectors;


### PR DESCRIPTION
- 프론트에 직무 유형 리스트를 제공하기 위한 API 입니다.
- 아직 직무 유형을 데이터베이스에 넣지 않았지만 조회 API를 우선 개발하였습니다.
- 이전에 리뷰 주신 `Member` 테이블에 `imageUrl` 수정 파라미터에 `@NotNull` 검증로직을 제거하였습니다.