### PR TITLE
[GOF-190] Member DELETE API 개발

### DIFF
--- a/src/main/java/com/forrestgof/jobscanner/auth/service/AuthService.java
+++ b/src/main/java/com/forrestgof/jobscanner/auth/service/AuthService.java
@@ -18,4 +18,6 @@ public interface AuthService {
 	AuthRefreshResponse refreshToken(String appToken, String refreshToken);
 
 	Member getMemberFromAppToken(String appToken);
+
+	void deleteSession(Member member);
 }

--- a/src/main/java/com/forrestgof/jobscanner/auth/service/DefaultAuthService.java
+++ b/src/main/java/com/forrestgof/jobscanner/auth/service/DefaultAuthService.java
@@ -1,5 +1,7 @@
 package com.forrestgof.jobscanner.auth.service;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
@@ -12,6 +14,7 @@ import com.forrestgof.jobscanner.auth.jwt.AuthTokenProvider;
 import com.forrestgof.jobscanner.mail.service.MailService;
 import com.forrestgof.jobscanner.member.domain.Member;
 import com.forrestgof.jobscanner.session.domain.Session;
+import com.forrestgof.jobscanner.session.repository.SessionRepository;
 import com.forrestgof.jobscanner.session.service.SessionService;
 import com.forrestgof.jobscanner.socialmember.domain.SocialMember;
 
@@ -23,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 public class DefaultAuthService implements AuthService {
 
 	private final SessionService sessionService;
+	private final SessionRepository sessionRepository;
 	private final AuthTokenProvider authTokenProvider;
 	private final MailService mailService;
 
@@ -143,5 +147,11 @@ public class DefaultAuthService implements AuthService {
 	}
 
 	private void deleteAuthToken(AuthToken authToken) {
+	}
+
+	@Override
+	public void deleteSession(Member member) {
+		List<Session> sessions = sessionRepository.findByMember(member);
+		sessionRepository.deleteAll(sessions);
 	}
 }

--- a/src/main/java/com/forrestgof/jobscanner/member/controller/MemberApiController.java
+++ b/src/main/java/com/forrestgof/jobscanner/member/controller/MemberApiController.java
@@ -3,6 +3,7 @@ package com.forrestgof.jobscanner.member.controller;
 import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -32,6 +33,7 @@ public class MemberApiController {
 		String appToken = JwtHeaderUtil.getAccessToken(request);
 
 		Member member = authService.getMemberFromAppToken(appToken);
+
 		MemberResponse memberResponse = MemberResponse.from(member);
 
 		return CustomResponse.success(memberResponse);
@@ -45,7 +47,20 @@ public class MemberApiController {
 		String appToken = JwtHeaderUtil.getAccessToken(request);
 
 		Member member = authService.getMemberFromAppToken(appToken);
+
 		memberService.updateMember(member.getId(), memberUpdateRequest);
+
+		return CustomResponse.success();
+	}
+
+	@DeleteMapping("")
+	public ResponseEntity<CustomResponse> deleteMember(HttpServletRequest request) {
+		String appToken = JwtHeaderUtil.getAccessToken(request);
+
+		Member member = authService.getMemberFromAppToken(appToken);
+
+		authService.deleteSession(member);
+		memberService.deleteMember(member.getId());
 
 		return CustomResponse.success();
 	}

--- a/src/main/java/com/forrestgof/jobscanner/member/service/DefaultMemberService.java
+++ b/src/main/java/com/forrestgof/jobscanner/member/service/DefaultMemberService.java
@@ -102,4 +102,15 @@ public class DefaultMemberService implements MemberService {
 		memberUpdateRequest.duties()
 				.ifPresent(duties -> memberDutyService.updateMemberDuty(findMember, duties));
 	}
+
+	@Override
+	@Transactional
+	public void deleteMember(Long memberId) {
+		Member findMember = memberRepository.findById(memberId)
+			.orElseThrow(MemberCustomException::notfound);
+
+		memberTagService.deleteMemberTag(findMember);
+		memberDutyService.deleteMemberDuty(findMember);
+		memberRepository.delete(findMember);
+	}
 }

--- a/src/main/java/com/forrestgof/jobscanner/member/service/MemberDutyService.java
+++ b/src/main/java/com/forrestgof/jobscanner/member/service/MemberDutyService.java
@@ -23,27 +23,24 @@ public class MemberDutyService {
 	private final MemberDutyRepository memberDutyRepository;
 	private final DutyRepository dutyRepository;
 
-	public List<Duty> findDutiesFromMember(Member member) {
-		List<MemberDuty> memberDuties = memberDutyRepository.findByMember(member);
-
-		return memberDuties.stream()
-			.map(MemberDuty::getDuty)
-			.collect(Collectors.toList());
-	}
-
 	@Transactional
 	public void updateMemberDuty(Member member, List<String> duties) {
-		List<MemberDuty> findDuties = memberDutyRepository.findByMember(member);
+		deleteMemberDuty(member);
 
-		memberDutyRepository.deleteAll(findDuties);
-
-		List<MemberDuty> updatedMemberDuties = duties.stream()
+		List<MemberDuty> memberDuties = duties.stream()
 			.map(dutyRepository::findByName)
 			.map(Optional::orElseThrow)
 			.map(duty -> MemberDuty.of(member, duty))
 			.map(memberDutyRepository::save)
 			.toList();
 
-		member.updateMemberDuties(updatedMemberDuties);
+		member.updateMemberDuties(memberDuties);
+	}
+
+	@Transactional
+	public void deleteMemberDuty(Member member) {
+		List<MemberDuty> findDuties = memberDutyRepository.findByMember(member);
+
+		memberDutyRepository.deleteAll(findDuties);
 	}
 }

--- a/src/main/java/com/forrestgof/jobscanner/member/service/MemberService.java
+++ b/src/main/java/com/forrestgof/jobscanner/member/service/MemberService.java
@@ -22,4 +22,6 @@ public interface MemberService {
 	void authenticateEmail(String email);
 
 	void updateMember(Long id, MemberPatchRequest memberUpdateRequest);
+
+	void deleteMember(Long memberId);
 }

--- a/src/main/java/com/forrestgof/jobscanner/member/service/MemberTagService.java
+++ b/src/main/java/com/forrestgof/jobscanner/member/service/MemberTagService.java
@@ -23,21 +23,11 @@ public class MemberTagService {
 	private final MemberTagRepository memberTagRepository;
 	private final TagRepository tagRepository;
 
-	public List<Tag> findTagsFromMember(Member member) {
-		List<MemberTag> memberTags = memberTagRepository.findByMember(member);
-
-		return memberTags.stream()
-			.map(MemberTag::getTag)
-			.collect(Collectors.toList());
-	}
-
 	@Transactional
 	public void updateMemberTag(Member member, List<String> tags) {
-		List<MemberTag> memberTags = memberTagRepository.findByMember(member);
+		deleteMemberTag(member);
 
-		memberTagRepository.deleteAll(memberTags);
-
-		List<MemberTag> updatedMemberTags = tags.stream()
+		List<MemberTag> memberTags = tags.stream()
 			.map(tagRepository::findByName)
 			.map(Optional::orElseThrow)
 			.map(tag -> MemberTag.of(member, tag))
@@ -45,5 +35,12 @@ public class MemberTagService {
 			.toList();
 
 		member.updateMemberTags(memberTags);
+	}
+
+	@Transactional
+	public void deleteMemberTag(Member member) {
+		List<MemberTag> memberTags = memberTagRepository.findByMember(member);
+
+		memberTagRepository.deleteAll(memberTags);
 	}
 }

--- a/src/main/java/com/forrestgof/jobscanner/session/repository/SessionRepository.java
+++ b/src/main/java/com/forrestgof/jobscanner/session/repository/SessionRepository.java
@@ -1,5 +1,6 @@
 package com.forrestgof.jobscanner.session.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,5 +14,5 @@ public interface SessionRepository extends JpaRepository<Session, Long> {
 
 	boolean existsByAppTokenUuidAndRefreshTokenUuid(String appTokenUuid, String refreshTokenUuid);
 
-	Optional<Session> findByMember(Member member);
+	List<Session> findByMember(Member member);
 }

--- a/src/main/java/com/forrestgof/jobscanner/session/service/DefaultSessionService.java
+++ b/src/main/java/com/forrestgof/jobscanner/session/service/DefaultSessionService.java
@@ -39,6 +39,6 @@ public class DefaultSessionService implements SessionService {
 	@Override
 	public Session findByMember(Member member) {
 		return sessionRepository.findByMember(member)
-			.orElseThrow();
+			.get(0);
 	}
 }


### PR DESCRIPTION
- 회원 탈퇴 기능을 위한 Member DELETE API 를 개발하였습니다.
- `Member` 삭제시 `Member`, `MemberTag`, `MemberDuty`, `Session` 이 같이 삭제되게 구현하였습니다.
- `MemberService`의 의존성 관리를 위해 `AuthService`에 `Session` 삭제 로직을 추가하였습니다.