### PR TITLE
[GOF-193] 조회수 기능 구현

### DIFF
--- a/src/main/java/com/forrestgof/jobscanner/common/dto/CustomResponse.java
+++ b/src/main/java/com/forrestgof/jobscanner/common/dto/CustomResponse.java
@@ -48,7 +48,7 @@ public class CustomResponse {
 	public static ResponseEntity<CustomResponse> error(Exception e) {
 		CustomResponse customResponse = CustomResponse.builder()
 			.status(false)
-			.message(e.getClass().getSimpleName() + ": " + e.getMessage())
+			.message(e.getClass().getSimpleName())
 			.build();
 
 		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/com/forrestgof/jobscanner/jobposting/controller/JobPostingApiController.java
+++ b/src/main/java/com/forrestgof/jobscanner/jobposting/controller/JobPostingApiController.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -53,11 +54,14 @@ public class JobPostingApiController {
 	}
 
 	@GetMapping("{id}")
+	@Transactional
 	public ResponseEntity<CustomResponse> getJob(
 		HttpServletRequest request,
 		@PathVariable Long id
 	) {
 		JobPosting jobPosting = jobPostingService.findOne(id);
+		jobPosting.increaseViews();
+
 		JobResponse jobResponse = new JobResponse(jobPosting);
 
 		try {

--- a/src/main/java/com/forrestgof/jobscanner/jobposting/controller/dto/JobResponse.java
+++ b/src/main/java/com/forrestgof/jobscanner/jobposting/controller/dto/JobResponse.java
@@ -29,6 +29,10 @@ public class JobResponse {
 
 	boolean bookmarkActivated;
 
+	int views;
+
+	int viewsPerWeek;
+
 	public JobResponse(JobPosting jobPosting) {
 		id = jobPosting.getId();
 		title = jobPosting.getTitle();
@@ -51,5 +55,7 @@ public class JobResponse {
 			.collect(Collectors.toList());
 		if (jobPosting.getJobDetail() != null)
 			jobDetail = new JobDetailDto(jobPosting.getJobDetail());
+		views = jobPosting.getViews();
+		viewsPerWeek = jobPosting.getViewsPerWeek();
 	}
 }

--- a/src/main/java/com/forrestgof/jobscanner/jobposting/domain/JobPosting.java
+++ b/src/main/java/com/forrestgof/jobscanner/jobposting/domain/JobPosting.java
@@ -71,11 +71,10 @@ public class JobPosting extends BaseTimeEntity {
 	private JobDetail jobDetail;
 
 	@OneToMany(mappedBy = "jobPosting")
-	private List<JobTag> jobTags = new ArrayList<>();
+	private final List<JobTag> jobTags = new ArrayList<>();
 
-	public void addJobTag(JobTag jobTag) {
-		jobTags.add(jobTag);
-	}
+	private int views;
+	private int viewsPerWeek;
 
 	@Builder
 	public JobPosting(
@@ -112,6 +111,10 @@ public class JobPosting extends BaseTimeEntity {
 		this.jobDetail = jobDetail;
 	}
 
+	public void addJobTag(JobTag jobTag) {
+		jobTags.add(jobTag);
+	}
+
 	public void updateFromPlatform(
 		String location,
 		LocalDate expiredAt,
@@ -124,5 +127,10 @@ public class JobPosting extends BaseTimeEntity {
 
 	public void expire() {
 		isExpired = true;
+	}
+
+	public void increaseViews() {
+		views++;
+		viewsPerWeek++;
 	}
 }


### PR DESCRIPTION
### 주요 변경사항
- 공고 상세 API가 호출될 때마다 공고에 있는 조회수를 증가시키는 로직을 작성하였습니다.
- 일주일 동안의 조회수는 현재 컬럼만 추가되어 있는 상태이고, 추후에 SpringBatch를 통해 매주 초기화할 예정입니다.

### 보안 이슈
- 현재 저희 API 반환 스펙의 message 부분에 예외 Trace가 출력되는 것을 확인하였습니다.
- 외부 반환 API의 경우 Stack Trace를 노출하게 되면 내부 구조를 노출하게 되기 때문에 보안 상에 문제가 발생할 수 있습니다.
- `CustomException`의 경우에만 예외 메시지를 추가로 출력하고, 저희가 확인하지 못한 Exception은 예외 클래스명 정도만 반환하게 수정하였습니다.