### PR TITLE
[GOF-206] 스웨거 이슈 해결을 위한 API 반환 정책 변경

### DIFF
--- a/src/main/java/com/forrestgof/jobscanner/common/dto/CustomResponse.java
+++ b/src/main/java/com/forrestgof/jobscanner/common/dto/CustomResponse.java
@@ -5,64 +5,60 @@ import org.springframework.http.ResponseEntity;
 
 import com.forrestgof.jobscanner.common.exception.CustomException;
 
-import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-@Builder
 @Getter
-public class CustomResponse {
+@NoArgsConstructor
+public class CustomResponse<T> {
 
 	boolean status;
 	String message;
-	Object data;
+	T data;
 
-	public static ResponseEntity<CustomResponse> success() {
-		CustomResponse customResponse = CustomResponse.builder()
-			.status(true)
-			.build();
+	public static CustomResponse<?> success() {
+		CustomResponse<?> customResponse = new CustomResponse<>();
 
-		return ResponseEntity.status(HttpStatus.OK)
-			.body(customResponse);
+		customResponse.status = true;
+
+		return customResponse;
 	}
 
-	public static ResponseEntity<CustomResponse> success(Object data) {
-		CustomResponse customResponse = CustomResponse.builder()
-			.status(true)
-			.data(data)
-			.build();
+	public static <T> CustomResponse<T> success(T data) {
+		CustomResponse<T> customResponse = new CustomResponse<>();
 
-		return ResponseEntity.status(HttpStatus.OK)
-			.body(customResponse);
+		customResponse.status = true;
+		customResponse.data = data;
+
+		return customResponse;
 	}
 
-	public static ResponseEntity<CustomResponse> success(Object data, HttpStatus httpStatus) {
-		CustomResponse customResponse = CustomResponse.builder()
-			.status(true)
-			.data(data)
-			.build();
+	public static <T> ResponseEntity<CustomResponse<T>> success(T data, HttpStatus httpStatus) {
+		CustomResponse<T> customResponse = new CustomResponse<>();
+
+		customResponse.status = true;
+		customResponse.data = data;
 
 		return ResponseEntity.status(httpStatus)
 			.body(customResponse);
 	}
 
-	public static ResponseEntity<CustomResponse> error(Exception e) {
-		CustomResponse customResponse = CustomResponse.builder()
-			.status(false)
-			.message(e.getClass().getSimpleName())
-			.build();
+	public static CustomResponse<?> error(Exception e) {
+		CustomResponse<?> customResponse = new CustomResponse<>();
 
-		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-			.body(customResponse);
+		customResponse.status = false;
+		customResponse.message = e.getClass().getSimpleName();
+
+		return customResponse;
 	}
 
-	public static ResponseEntity<CustomResponse> customError(CustomException e) {
-		CustomResponse customResponse = CustomResponse.builder()
-			.status(false)
-			.message(e.getClass().getSimpleName() + ": " + e.getMessage())
-			.build();
+	public static CustomResponse<?> customError(CustomException e) {
+		CustomResponse<?> customResponse = new CustomResponse<>();
 
-		return ResponseEntity.status(e.getHttpStatus())
-			.body(customResponse);
+		customResponse.status = false;
+		customResponse.message = e.getClass().getSimpleName() + ": " + e.getMessage();
+
+		return customResponse;
 	}
 }
 

--- a/src/main/java/com/forrestgof/jobscanner/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/forrestgof/jobscanner/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,5 @@
 package com.forrestgof.jobscanner.common.exception;
 
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -13,13 +12,13 @@ import lombok.extern.log4j.Log4j2;
 public class GlobalExceptionHandler {
 
 	@ExceptionHandler
-	public ResponseEntity<CustomResponse> handleUnExpectedException(Exception e) {
+	public CustomResponse<?> handleUnExpectedException(Exception e) {
 		log.error("UnExpected Exception", e);
 		return CustomResponse.error(e);
 	}
 
 	@ExceptionHandler
-	public ResponseEntity<CustomResponse> handleCustomException(CustomException e) {
+	public CustomResponse<?> handleCustomException(CustomException e) {
 		log.error("Custom Exception", e);
 		return CustomResponse.customError(e);
 	}

--- a/src/main/java/com/forrestgof/jobscanner/duty/controller/DutyApiController.java
+++ b/src/main/java/com/forrestgof/jobscanner/duty/controller/DutyApiController.java
@@ -2,9 +2,10 @@ package com.forrestgof.jobscanner.duty.controller;
 
 import java.util.List;
 
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.forrestgof.jobscanner.common.dto.CustomResponse;
@@ -21,7 +22,8 @@ public class DutyApiController {
 	private final DutyService dutyService;
 
 	@GetMapping
-	public ResponseEntity<CustomResponse> getDuties() {
+	@ResponseStatus(HttpStatus.OK)
+	public CustomResponse<List<String>> getDuties() {
 		List<String> duties = dutyService.findAll()
 			.stream()
 			.map(Duty::getName)

--- a/src/main/java/com/forrestgof/jobscanner/member/controller/MemberApiController.java
+++ b/src/main/java/com/forrestgof/jobscanner/member/controller/MemberApiController.java
@@ -2,12 +2,13 @@ package com.forrestgof.jobscanner.member.controller;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.forrestgof.jobscanner.auth.jwt.JwtHeaderUtil;
@@ -29,7 +30,8 @@ public class MemberApiController {
 	private final MemberService memberService;
 
 	@GetMapping("")
-	public ResponseEntity<CustomResponse> getMember(HttpServletRequest request) {
+	@ResponseStatus(HttpStatus.OK)
+	public CustomResponse<MemberResponse> getMember(HttpServletRequest request) {
 		String appToken = JwtHeaderUtil.getAccessToken(request);
 
 		Member member = authService.getMemberFromAppToken(appToken);
@@ -40,7 +42,8 @@ public class MemberApiController {
 	}
 
 	@PatchMapping("")
-	public ResponseEntity<CustomResponse> patchMember(
+	@ResponseStatus(HttpStatus.OK)
+	public CustomResponse<?> patchMember(
 		HttpServletRequest request,
 		@RequestBody MemberPatchRequest memberUpdateRequest
 	) {
@@ -54,7 +57,8 @@ public class MemberApiController {
 	}
 
 	@DeleteMapping("")
-	public ResponseEntity<CustomResponse> deleteMember(HttpServletRequest request) {
+	@ResponseStatus(HttpStatus.OK)
+	public CustomResponse<?> deleteMember(HttpServletRequest request) {
 		String appToken = JwtHeaderUtil.getAccessToken(request);
 
 		Member member = authService.getMemberFromAppToken(appToken);

--- a/src/main/java/com/forrestgof/jobscanner/tag/controller/TagApiController.java
+++ b/src/main/java/com/forrestgof/jobscanner/tag/controller/TagApiController.java
@@ -3,10 +3,10 @@ package com.forrestgof.jobscanner.tag.controller;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.forrestgof.jobscanner.common.dto.CustomResponse;
@@ -23,7 +23,8 @@ public class TagApiController {
 	private final TagService tagService;
 
 	@GetMapping
-	public ResponseEntity<CustomResponse> getTags() {
+	@ResponseStatus(HttpStatus.OK)
+	public CustomResponse<List<String>> getTags() {
 		List<String> tags = tagService.findAll()
 			.stream()
 			.map(Tag::getName)


### PR DESCRIPTION
- `ResponseEntity` 대신 `@RestController` + `@ResponseStatus` 적용
- 동적으로 상태 코드를 변경해야 하는 로직은 기존 방식 유지