### PR TITLE
[HOTFIX] 직무 조회 API CORS 허용

### DIFF
--- a/src/main/java/com/forrestgof/jobscanner/common/config/SecurityConfig.java
+++ b/src/main/java/com/forrestgof/jobscanner/common/config/SecurityConfig.java
@@ -30,12 +30,13 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 	}
 
 	@Override
-	public void configure(WebSecurity web) throws Exception {
+	public void configure(WebSecurity web) {
 		web.ignoring().antMatchers(
 			"/",
 			"/jobs/**",
 			"/auth/**",
 			"/tags/**",
+			"/duties/**",
 
 			/* swagger v2 */
 			"/v2/api-docs",

--- a/src/main/java/com/forrestgof/jobscanner/jobposting/controller/JobPostingApiController.java
+++ b/src/main/java/com/forrestgof/jobscanner/jobposting/controller/JobPostingApiController.java
@@ -81,7 +81,7 @@ public class JobPostingApiController {
 
 	@GetMapping("bookmarks")
 	@ResponseStatus(HttpStatus.OK)
-	public CustomResponse<List<JobPreviewResponse>> getLike(
+	public CustomResponse<List<JobPreviewResponse>> getBookmark(
 		HttpServletRequest request
 	) {
 		Member member = getMember(request);
@@ -94,7 +94,7 @@ public class JobPostingApiController {
 
 	@PutMapping("bookmarks/{jobPostingId}")
 	@ResponseStatus(HttpStatus.OK)
-	public CustomResponse<?> updateLike(
+	public CustomResponse<?> updateBookmark(
 		HttpServletRequest request,
 		@PathVariable Long jobPostingId,
 		@RequestBody BookmarkJobRequest bookmarkJobRequest


### PR DESCRIPTION
- `/duties` API CORS 허용을 위해 `SecurityConfig`를 수정하였습니다.
- 북마크 컨트롤러에서 메서드 이름을 변경하였습니다.