### PR TITLE
CustomException 상태 코드 반영

### DIFF
--- a/src/main/java/com/forrestgof/jobscanner/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/forrestgof/jobscanner/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.forrestgof.jobscanner.common.exception;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -17,13 +18,15 @@ public class GlobalExceptionHandler {
 	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
 	public CustomResponse<?> handleUnExpectedException(Exception e) {
 		log.error("UnExpected Exception", e);
+
 		return CustomResponse.error(e);
 	}
 
 	@ExceptionHandler
-	@ResponseStatus(HttpStatus.BAD_REQUEST)
-	public CustomResponse<?> handleCustomException(CustomException e) {
+	public ResponseEntity<CustomResponse<?>> handleCustomException(CustomException e) {
 		log.error("Custom Exception", e);
-		return CustomResponse.customError(e);
+
+		return ResponseEntity.status(e.getHttpStatus())
+			.body(CustomResponse.customError(e));
 	}
 }


### PR DESCRIPTION
- 넘어오는 예외에 담겨있는 HttpStatus를 반영하기 위해 CustomException 핸들러가 ResponseEntity를 반환하게 수정하였습니다.
- 예외의 경우 data 필드가 비어있기 때문에 ResponseEntity를 반환해도 괜찮을 것 같습니다.