### PR TITLE
[GOF-207] 공고 API 스펙 변경 및 RESTful API 개선

### DIFF
--- a/src/main/java/com/forrestgof/jobscanner/auth/controller/AuthController.java
+++ b/src/main/java/com/forrestgof/jobscanner/auth/controller/AuthController.java
@@ -68,18 +68,16 @@ public class AuthController {
 
 	@PostMapping("signin")
 	@ResponseStatus(HttpStatus.NO_CONTENT)
-	public CustomResponse<?> signIn(
+	public void signIn(
 		@RequestBody
 		@Valid
 		SignInRequest signInRequest
 	) {
 		memberService.signIn(signInRequest);
-
-		return CustomResponse.success();
 	}
 
 	@PostMapping("refresh")
-	@ResponseStatus(HttpStatus.OK)
+	@ResponseStatus(HttpStatus.CREATED)
 	public CustomResponse<AuthRefreshResponse> refreshToken(HttpServletRequest request) {
 		String appToken = JwtHeaderUtil.getAccessToken(request);
 		String refreshToken = JwtHeaderUtil.getRefreshToken(request);
@@ -91,11 +89,12 @@ public class AuthController {
 
 	@GetMapping("signin/callback/{socialType}")
 	@ResponseStatus(HttpStatus.NO_CONTENT)
-	public CustomResponse<?> socialSignIn(
+	public void socialSignIn(
 		@PathVariable("socialType") String type,
 		@RequestParam String code,
 		HttpServletResponse response
 	) throws IOException {
+
 		SocialType socialType = SocialType.getEnum(type);
 		SocialService socialService = socialServiceFactory.find(socialType);
 
@@ -111,8 +110,6 @@ public class AuthController {
 		response.sendRedirect(domainProperties.webSite() +
 			"/oauth/callback/" + socialType.getName() +
 			"?appToken=" + authTokenResponse.getAppToken());
-
-		return CustomResponse.success();
 	}
 
 	@ExceptionHandler(SocialMemberException.class)
@@ -131,7 +128,7 @@ public class AuthController {
 
 	@GetMapping("mail/authenticate/{email}/{appToken}")
 	@ResponseStatus(HttpStatus.NO_CONTENT)
-	public CustomResponse<?> authenticateMail(
+	public void authenticateMail(
 		@PathVariable String email,
 		@PathVariable String appToken,
 		HttpServletResponse response
@@ -141,13 +138,11 @@ public class AuthController {
 		memberService.authenticateEmail(email);
 
 		response.sendRedirect(domainProperties.webSite());
-
-		return CustomResponse.success();
 	}
 
 	@GetMapping("signin/{socialType}")
 	@ResponseStatus(HttpStatus.NO_CONTENT)
-	public CustomResponse<?> socialRedirect(
+	public void socialRedirect(
 		@PathVariable("socialType") String type,
 		HttpServletResponse response
 	) throws IOException {
@@ -156,8 +151,6 @@ public class AuthController {
 		SocialService socialService = socialServiceFactory.find(socialType);
 
 		response.sendRedirect(socialService.getRedirectUrl());
-
-		return CustomResponse.success();
 	}
 
 	private SocialMember socialSignUp(Member member, SocialType socialTYpe) {

--- a/src/main/java/com/forrestgof/jobscanner/auth/controller/AuthController.java
+++ b/src/main/java/com/forrestgof/jobscanner/auth/controller/AuthController.java
@@ -67,7 +67,7 @@ public class AuthController {
 	}
 
 	@PostMapping("signin")
-	@ResponseStatus(HttpStatus.OK)
+	@ResponseStatus(HttpStatus.NO_CONTENT)
 	public CustomResponse<?> signIn(
 		@RequestBody
 		@Valid
@@ -90,8 +90,8 @@ public class AuthController {
 	}
 
 	@GetMapping("signin/callback/{socialType}")
-	@ResponseStatus(HttpStatus.OK)
-	public CustomResponse socialSignIn(
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public CustomResponse<?> socialSignIn(
 		@PathVariable("socialType") String type,
 		@RequestParam String code,
 		HttpServletResponse response
@@ -130,8 +130,8 @@ public class AuthController {
 	}
 
 	@GetMapping("mail/authenticate/{email}/{appToken}")
-	@ResponseStatus(HttpStatus.OK)
-	public CustomResponse authenticateMail(
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public CustomResponse<?> authenticateMail(
 		@PathVariable String email,
 		@PathVariable String appToken,
 		HttpServletResponse response
@@ -146,8 +146,8 @@ public class AuthController {
 	}
 
 	@GetMapping("signin/{socialType}")
-	@ResponseStatus(HttpStatus.OK)
-	public CustomResponse socialRedirect(
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public CustomResponse<?> socialRedirect(
 		@PathVariable("socialType") String type,
 		HttpServletResponse response
 	) throws IOException {

--- a/src/main/java/com/forrestgof/jobscanner/common/dto/CustomResponse.java
+++ b/src/main/java/com/forrestgof/jobscanner/common/dto/CustomResponse.java
@@ -13,14 +13,6 @@ public class CustomResponse<T> {
 	String message;
 	T data;
 
-	public static CustomResponse<?> success() {
-		CustomResponse<?> customResponse = new CustomResponse<>();
-
-		customResponse.status = true;
-
-		return customResponse;
-	}
-
 	public static <T> CustomResponse<T> success(T data) {
 		CustomResponse<T> customResponse = new CustomResponse<>();
 

--- a/src/main/java/com/forrestgof/jobscanner/common/dto/CustomResponse.java
+++ b/src/main/java/com/forrestgof/jobscanner/common/dto/CustomResponse.java
@@ -39,5 +39,14 @@ public class CustomResponse<T> {
 
 		return customResponse;
 	}
+
+	public static CustomResponse<?> errorWithMessage(String message) {
+		CustomResponse<?> customResponse = new CustomResponse<>();
+
+		customResponse.status = false;
+		customResponse.message = message;
+
+		return customResponse;
+	}
 }
 

--- a/src/main/java/com/forrestgof/jobscanner/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/forrestgof/jobscanner/common/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.forrestgof.jobscanner.common.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -28,5 +29,13 @@ public class GlobalExceptionHandler {
 
 		return ResponseEntity.status(e.getHttpStatus())
 			.body(CustomResponse.customError(e));
+	}
+
+	@ExceptionHandler
+	@ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
+	public CustomResponse<?> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+		log.error("Http Request Method Not Supported Exception", e);
+
+		return CustomResponse.errorWithMessage("Http request method is not supported");
 	}
 }

--- a/src/main/java/com/forrestgof/jobscanner/jobposting/controller/JobPostingApiController.java
+++ b/src/main/java/com/forrestgof/jobscanner/jobposting/controller/JobPostingApiController.java
@@ -50,7 +50,7 @@ public class JobPostingApiController {
 	) {
 		List<JobPosting> findJobs = jobPostingService.findFilterJobs(jobSearchCondition);
 
-		List<JobPreviewResponse> previewDtos = parseToDtoList(findJobs);
+		List<JobPreviewResponse> jobPreviewResponses = parseToDtoList(findJobs);
 
 		Set<Long> bookmarkJobs = getMember(request)
 			.map(bookmarkJobService::findBookmarkJobPosting)
@@ -59,12 +59,12 @@ public class JobPostingApiController {
 			.map(JobPosting::getId)
 			.collect(Collectors.toSet());
 
-		previewDtos.stream()
+		jobPreviewResponses.stream()
 			.filter(jobPreviewResponse ->
 				bookmarkJobs.contains(jobPreviewResponse.getId()))
 			.forEach(JobPreviewResponse::activateBookmark);
 
-		Result result = new Result(previewDtos, previewDtos.size());
+		Result result = new Result(jobPreviewResponses, jobPreviewResponses.size());
 
 		return CustomResponse.success(result);
 	}

--- a/src/main/java/com/forrestgof/jobscanner/jobposting/controller/JobPostingApiController.java
+++ b/src/main/java/com/forrestgof/jobscanner/jobposting/controller/JobPostingApiController.java
@@ -93,7 +93,7 @@ public class JobPostingApiController {
 	}
 
 	@PutMapping("bookmarks/{jobPostingId}")
-	@ResponseStatus(HttpStatus.OK)
+	@ResponseStatus(HttpStatus.NO_CONTENT)
 	public CustomResponse<?> updateBookmark(
 		HttpServletRequest request,
 		@PathVariable Long jobPostingId,

--- a/src/main/java/com/forrestgof/jobscanner/jobposting/controller/JobPostingApiController.java
+++ b/src/main/java/com/forrestgof/jobscanner/jobposting/controller/JobPostingApiController.java
@@ -111,8 +111,8 @@ public class JobPostingApiController {
 	}
 
 	@PutMapping("bookmarks/{jobPostingId}")
-	@ResponseStatus(HttpStatus.NO_CONTENT)
-	public CustomResponse<?> updateBookmark(
+	@ResponseStatus(HttpStatus.CREATED)
+	public CustomResponse<BookmarkJobRequest> updateBookmark(
 		HttpServletRequest request,
 		@PathVariable Long jobPostingId,
 		@RequestBody BookmarkJobRequest bookmarkJobRequest
@@ -124,7 +124,7 @@ public class JobPostingApiController {
 
 		bookmarkJobService.updateLike(jobPosting, member, bookmarkJobRequest);
 
-		return CustomResponse.success();
+		return CustomResponse.success(bookmarkJobRequest);
 	}
 
 	private List<JobPreviewResponse> parseToDtoList(List<JobPosting> find) {

--- a/src/main/java/com/forrestgof/jobscanner/jobposting/controller/dto/JobPreviewResponse.java
+++ b/src/main/java/com/forrestgof/jobscanner/jobposting/controller/dto/JobPreviewResponse.java
@@ -20,6 +20,12 @@ public class JobPreviewResponse {
 	String postedAt;
 	String expiredAt;
 	List<String> tags;
+	int views;
+	boolean bookmarkActivated;
+
+	public void activateBookmark() {
+		this.bookmarkActivated = true;
+	}
 
 	public JobPreviewResponse(JobPosting jobPosting) {
 		id = jobPosting.getId();
@@ -36,5 +42,6 @@ public class JobPreviewResponse {
 			.map(JobTag::getTag)
 			.map(Tag::getName)
 			.collect(Collectors.toList());
+		views = jobPosting.getViews();
 	}
 }

--- a/src/main/java/com/forrestgof/jobscanner/jobposting/controller/dto/JobResponse.java
+++ b/src/main/java/com/forrestgof/jobscanner/jobposting/controller/dto/JobResponse.java
@@ -26,12 +26,13 @@ public class JobResponse {
 	String summary;
 	List<String> tags;
 	JobDetailDto jobDetail;
-
+	int views;
+	int viewsPerWeek;
 	boolean bookmarkActivated;
 
-	int views;
-
-	int viewsPerWeek;
+	public void activateBookmark() {
+		this.bookmarkActivated = true;
+	}
 
 	public JobResponse(JobPosting jobPosting) {
 		id = jobPosting.getId();

--- a/src/main/java/com/forrestgof/jobscanner/jobposting/exception/JobPostingCustomException.java
+++ b/src/main/java/com/forrestgof/jobscanner/jobposting/exception/JobPostingCustomException.java
@@ -1,0 +1,16 @@
+package com.forrestgof.jobscanner.jobposting.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.forrestgof.jobscanner.common.exception.CustomException;
+
+public class JobPostingCustomException extends CustomException {
+
+	public JobPostingCustomException(String message, HttpStatus httpStatus) {
+		super(message, httpStatus);
+	}
+
+	public static JobPostingCustomException notfound() {
+		return new JobPostingCustomException("Not found Job", HttpStatus.NOT_FOUND);
+	}
+}

--- a/src/main/java/com/forrestgof/jobscanner/jobposting/service/DefaultJobPostingService.java
+++ b/src/main/java/com/forrestgof/jobscanner/jobposting/service/DefaultJobPostingService.java
@@ -1,13 +1,13 @@
 package com.forrestgof.jobscanner.jobposting.service;
 
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.forrestgof.jobscanner.jobposting.controller.dto.JobSearchCondition;
 import com.forrestgof.jobscanner.jobposting.domain.JobPosting;
+import com.forrestgof.jobscanner.jobposting.exception.JobPostingCustomException;
 import com.forrestgof.jobscanner.jobposting.repository.JobPostingRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -33,7 +33,7 @@ public class DefaultJobPostingService implements JobPostingService {
 	@Override
 	public JobPosting findOne(Long id) {
 		return jobPostingRepository.findById(id)
-			.orElseThrow();
+			.orElseThrow(JobPostingCustomException::notfound);
 	}
 
 	@Override

--- a/src/main/java/com/forrestgof/jobscanner/member/controller/MemberApiController.java
+++ b/src/main/java/com/forrestgof/jobscanner/member/controller/MemberApiController.java
@@ -42,8 +42,8 @@ public class MemberApiController {
 	}
 
 	@PatchMapping("")
-	@ResponseStatus(HttpStatus.NO_CONTENT)
-	public CustomResponse<?> patchMember(
+	@ResponseStatus(HttpStatus.CREATED)
+	public CustomResponse<MemberResponse> patchMember(
 		HttpServletRequest request,
 		@RequestBody MemberPatchRequest memberUpdateRequest
 	) {
@@ -53,19 +53,19 @@ public class MemberApiController {
 
 		memberService.updateMember(member.getId(), memberUpdateRequest);
 
-		return CustomResponse.success();
+		MemberResponse memberResponse = MemberResponse.from(member);
+
+		return CustomResponse.success(memberResponse);
 	}
 
 	@DeleteMapping("")
 	@ResponseStatus(HttpStatus.NO_CONTENT)
-	public CustomResponse<?> deleteMember(HttpServletRequest request) {
+	public void deleteMember(HttpServletRequest request) {
 		String appToken = JwtHeaderUtil.getAccessToken(request);
 
 		Member member = authService.getMemberFromAppToken(appToken);
 
 		authService.deleteSession(member);
 		memberService.deleteMember(member.getId());
-
-		return CustomResponse.success();
 	}
 }

--- a/src/main/java/com/forrestgof/jobscanner/member/controller/MemberApiController.java
+++ b/src/main/java/com/forrestgof/jobscanner/member/controller/MemberApiController.java
@@ -42,7 +42,7 @@ public class MemberApiController {
 	}
 
 	@PatchMapping("")
-	@ResponseStatus(HttpStatus.OK)
+	@ResponseStatus(HttpStatus.NO_CONTENT)
 	public CustomResponse<?> patchMember(
 		HttpServletRequest request,
 		@RequestBody MemberPatchRequest memberUpdateRequest
@@ -57,7 +57,7 @@ public class MemberApiController {
 	}
 
 	@DeleteMapping("")
-	@ResponseStatus(HttpStatus.OK)
+	@ResponseStatus(HttpStatus.NO_CONTENT)
 	public CustomResponse<?> deleteMember(HttpServletRequest request) {
 		String appToken = JwtHeaderUtil.getAccessToken(request);
 

--- a/src/main/java/com/forrestgof/jobscanner/member/exception/MemberCustomException.java
+++ b/src/main/java/com/forrestgof/jobscanner/member/exception/MemberCustomException.java
@@ -1,5 +1,7 @@
 package com.forrestgof.jobscanner.member.exception;
 
+import org.springframework.http.HttpStatus;
+
 import com.forrestgof.jobscanner.common.exception.CustomException;
 
 public class MemberCustomException extends CustomException {
@@ -7,7 +9,11 @@ public class MemberCustomException extends CustomException {
 		super(message);
 	}
 
+	public MemberCustomException(String message, HttpStatus httpStatus) {
+		super(message, httpStatus);
+	}
+
 	public static MemberCustomException notfound() {
-		return new MemberCustomException("Not found Member");
+		return new MemberCustomException("Not found Member", HttpStatus.NOT_FOUND);
 	}
 }


### PR DESCRIPTION
> API 스펙 변경점을 포함하는 PR이기 때문에 영민님 Approve까지 받고 merge 진행하겠습니다.

## API 스펙 변경
- 공고 목록 API에 조회수와 즐겨찾기 정보를 추가했습니다.
    - 로그인된 회원의 경우 즐겨찾기 정보가 갱신되어 반환됩니다. (구현 완료)
    - 공고 목록에는 일주일 간 측정된 조회수(`viewsPerWeek`)를 반환하지 않습니다.
        - 일주일 조회수는 모달 팝업 형태로 제공되는 것으로 알고 있기 때문에 반환하지 않았습니다.
        - 만약 필요하다고 판단되시면 필드 추가만 하면 되는 간단한 작업이라 언제든지 편하게 말씀해주셔도 됩니다.
        
- API를 좀 더 RESTful하게 개선하였습니다.
    - `PUT`과 `PATCH`는 변경된 리소스와 함께 **201 Created**를 반환합니다.
    - `jobs/{id}`에서 리소스가 존재하지 없으면 **404 Not found**를 반환합니다.
    - `DELETE`는 **204 No Content**를 반환합니다.
        - 204 No Content는 Body 부분이 비어있습니다.
        - 따라서 `"status": true, "message": null, "data": { }` 형태의 응답은 이제 반환하지 않습니다.
    - 지원하지 않는 Http 메서드는 **405 Method Not Allowed**를 반환합니다.
        - 어제 발생했었던 PATCH와 PUT을 잘못 사용하여 발생했던 문제점이 생각나서 추가했습니다.
        
- 위 내용들도 전부 Swagger에 반영되니 merge 이후에 Swagger를 통해 확인하실 수 있습니다.

## 구현 특이사항
- 공고 목록에서 즐겨찾기 여부를 검사할 때 각각의 공고를 하나하나 검사하게 되면 데이터베이스에 쿼리가 너무 많이 나가는 문제점이 발견되었습니다.
- 따라서 공고 목록 요청이 들어오면 미리 사용자가 즐겨찾기 한 공고 목록을 전부 받아와 해시로 관리하였습니다.
- 이후 조회해 온 공고 목록을 순회하면서 받아온 해시에 대입해 즐겨찾기 여부를 갱신하였습니다.
- 위 모든 과정을 Optional과 Stream(map)을 활용하여 가독성있는 코드로 작성하였습니다.

## 리펙토링
- 공고 쪽에서 Member를 조회하는 로직을 리펙토링 하였습니다.
- 기존에는 public 함수에 try-catch 로직이 존재하여 가독성이 떨어졌는데 이를 optional로 반환하는 private 함수를 정의하여 개선하였습니다.