### PR TITLE
[버그 수정] 단일 공고 조회에서 즐겨찾기 정보가 갱신되지 않았던 버그를 수정하였습니다.

### DIFF
--- a/src/main/java/com/forrestgof/jobscanner/jobposting/controller/JobPostingApiController.java
+++ b/src/main/java/com/forrestgof/jobscanner/jobposting/controller/JobPostingApiController.java
@@ -89,6 +89,7 @@ public class JobPostingApiController {
 		JobResponse jobResponse = new JobResponse(jobPosting);
 
 		getMember(request)
+			.filter(member -> bookmarkJobService.checkActivation(jobPosting, member))
 			.ifPresent(member -> jobResponse.activateBookmark());
 
 		return CustomResponse.success(jobResponse);


### PR DESCRIPTION
- Member만 조회하고 true로 체크했던 실수가 있었습니다.
- 조회한 Member를 바탕으로 즐겨찾기 여부를 검사하는 로직을 추가하였습니다.