### PR TITLE
문제가 발견되어서 HTTP request, response 로그 설정 해제 해두었습니다.

### DIFF
--- a/src/main/java/com/forrestgof/jobscanner/common/logging/LoggingFilter.java
+++ b/src/main/java/com/forrestgof/jobscanner/common/logging/LoggingFilter.java
@@ -13,12 +13,11 @@ import javax.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
-import org.springframework.stereotype.Component;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
-@Component
+// @Component
 public class LoggingFilter extends OncePerRequestFilter {
 	protected static final Logger log = LoggerFactory.getLogger(LoggingFilter.class);
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -18,9 +18,6 @@
     </appender>
 
     <appender name="aws_cloud_watch_log" class="ca.pjer.logback.AwsLogsAppender">
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>INFO</level>
-        </filter>
         <layout>
             <pattern>[%thread] [%level] [%file:%line] - %msg%n</pattern>
         </layout>
@@ -61,6 +58,7 @@
 
     <springProfile name="default">
         <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
             <appender-ref ref="aws_cloud_watch_log"/>
             <appender-ref ref="aws_cloud_watch_error"/>
         </root>


### PR DESCRIPTION
문제점
- HTTP request가 오면 reponse와 함께 로그를 찍도록 필터를 설정했습니다.
- 해당 로그를 Cloudwatch로 전송합니다
    
![image](https://user-images.githubusercontent.com/58173061/191807514-95e24a30-9bcc-4947-b1d5-26f1d29915e4.png)    

- 로컬 환경에서는 아무 문제가 없는데 서버에서 jar를 실행하면 문제가 있습니다
- 아래 사진과 같이 0.3초 마다 Request 로그가 찍힙니다.
    
![image](https://user-images.githubusercontent.com/58173061/191807597-419d090b-2e43-4eba-a902-5d2b66eb0535.png)
    
- uri=/인 Request가 오면 응답이 없어서 Response 로그가 없을 수는 있는데, 서버에서 실행하면 계속 Request 로그가 찍히는 상황입니다.

- 서버 환경에 대해 좀 더 알아보거나, 다르게 로그 모니터링하는 방법을 찾아보고 적용해보겠습니다.
- 우선 계속 로그가 찍혀서 서버 인스턴스를 중지해놨는데, 계속 서버 인스턴스를 중지해놓을 수는 없으니 HTTP request, reponse 로깅 설정을 하지 않은 기본적인 spring 로그만 찍히도록 수정해서 PR 합니다.