### PR TITLE
깃허브 이메일 문제 해결했습니다.

### DIFF
--- a/src/main/java/com/forrestgof/jobscanner/auth/social/SocialServiceFactory.java
+++ b/src/main/java/com/forrestgof/jobscanner/auth/social/SocialServiceFactory.java
@@ -14,13 +14,13 @@ public class SocialServiceFactory {
 
 	private final KakaoService kakaoTokenValidator;
 	private final GoogleService googleTokenValidator;
-	// private final GithubService githubTokenValidator;
+	private final GithubService githubTokenValidator;
 
 	public SocialService find(SocialType socialType) {
 		return switch (socialType) {
 			case KAKAO -> kakaoTokenValidator;
 			case GOOGLE -> googleTokenValidator;
-			// case GITHUB -> githubTokenValidator;
+			case GITHUB -> githubTokenValidator;
 		};
 	}
 }

--- a/src/main/java/com/forrestgof/jobscanner/auth/social/dto/GithubEmailResponse.java
+++ b/src/main/java/com/forrestgof/jobscanner/auth/social/dto/GithubEmailResponse.java
@@ -1,0 +1,15 @@
+package com.forrestgof.jobscanner.auth.social.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GithubEmailResponse {
+
+	private String email;
+}

--- a/src/main/java/com/forrestgof/jobscanner/auth/social/dto/GithubUserResponse.java
+++ b/src/main/java/com/forrestgof/jobscanner/auth/social/dto/GithubUserResponse.java
@@ -4,18 +4,16 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
-@ToString
-@Getter
+@Data
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class GithubUserResponse {
 
-	private String login;
+	private String login; // nickname
 	private String email;
 	private String avatarUrl;
 }

--- a/src/main/java/com/forrestgof/jobscanner/socialmember/domain/SocialType.java
+++ b/src/main/java/com/forrestgof/jobscanner/socialmember/domain/SocialType.java
@@ -12,8 +12,8 @@ import lombok.Getter;
 public enum SocialType {
 
 	KAKAO("kakao"),
-	GOOGLE("google");
-	// GITHUB("github");
+	GOOGLE("google"),
+	GITHUB("github");
 
 	private final String name;
 


### PR DESCRIPTION
- 깃허브 OAuth 로그인 할 때, 유저의 public email이 없으면 예외가 발생했습니다.
- 깃허브 문서 찾아보니 Email API가 별도로 따로 있어서, OAuth 로그인시 동의를 받고 public email이 없으면 private email을 가져오도록 로직을 추가했습니다.
- 서버에서 모든 OAuth 로그인 로직을 처리하기로 해서 Github OAuth 실패시 redirect가 무한 루프되는 일은 없을 것 같습니다.
- 만약 서버에 무한 루프가 발생하면 CPU 사용율 80% 넘어갈 때 Slack 알람 보내고 인스턴스 중지하게 세팅했습니다.