### PR TITLE
HTTP request, response 로그 문제 해결했습니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.netty:netty-resolver-dns-native-macos:4.1.81.Final:osx-aarch_64'
 
     //Certification

--- a/src/main/java/com/forrestgof/jobscanner/common/config/PropertiesConfig.java
+++ b/src/main/java/com/forrestgof/jobscanner/common/config/PropertiesConfig.java
@@ -5,13 +5,15 @@ import org.springframework.context.annotation.Configuration;
 
 import com.forrestgof.jobscanner.common.config.properties.ApiProperties;
 import com.forrestgof.jobscanner.common.config.properties.AuthProperties;
+import com.forrestgof.jobscanner.common.config.properties.AwsProperties;
 import com.forrestgof.jobscanner.common.config.properties.DomainProperties;
 
 @Configuration
 @EnableConfigurationProperties(value = {
 	ApiProperties.class,
 	AuthProperties.class,
-	DomainProperties.class
+	DomainProperties.class,
+	AwsProperties.class
 })
 public class PropertiesConfig {
 }

--- a/src/main/java/com/forrestgof/jobscanner/common/config/SecurityConfig.java
+++ b/src/main/java/com/forrestgof/jobscanner/common/config/SecurityConfig.java
@@ -49,7 +49,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
 			/* swagger v3 */
 			"/v3/api-docs/**",
-			"/swagger-ui/**"
+			"/swagger-ui/**",
+
+			/* actuator */
+			"/actuator/**"
 		);
 	}
 

--- a/src/main/java/com/forrestgof/jobscanner/common/config/SwaggerConfig.java
+++ b/src/main/java/com/forrestgof/jobscanner/common/config/SwaggerConfig.java
@@ -1,7 +1,14 @@
 package com.forrestgof.jobscanner.common.config;
 
+import java.lang.reflect.Field;
+import java.util.List;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfoHandlerMapping;
 
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
@@ -9,6 +16,8 @@ import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.spring.web.plugins.WebFluxRequestHandlerProvider;
+import springfox.documentation.spring.web.plugins.WebMvcRequestHandlerProvider;
 
 @Configuration
 public class SwaggerConfig {
@@ -30,5 +39,42 @@ public class SwaggerConfig {
 			// .description("springboot rest api practice.")
 			.version("1.0")
 			.build();
+	}
+
+	@Bean
+	public static BeanPostProcessor springfoxHandlerProviderBeanPostProcessor() {
+		return new BeanPostProcessor() {
+
+			@Override
+			public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+				if (bean instanceof WebMvcRequestHandlerProvider ||
+					bean instanceof WebFluxRequestHandlerProvider
+				) {
+					customizeSpringfoxHandlerMappings(getHandlerMappings(bean));
+				}
+				return bean;
+			}
+
+			private <T extends RequestMappingInfoHandlerMapping> void customizeSpringfoxHandlerMappings(List<T> mappings
+			) {
+				List<T> copy = mappings.stream()
+					.filter(mapping -> mapping.getPatternParser() == null)
+					.toList();
+				mappings.clear();
+				mappings.addAll(copy);
+			}
+
+			@SuppressWarnings("unchecked")
+			private List<RequestMappingInfoHandlerMapping> getHandlerMappings(Object bean) {
+				try {
+					Field field = ReflectionUtils.findField(bean.getClass(), "handlerMappings");
+					assert field != null;
+					field.setAccessible(true);
+					return (List<RequestMappingInfoHandlerMapping>)field.get(bean);
+				} catch (IllegalArgumentException | IllegalAccessException e) {
+					throw new IllegalStateException(e);
+				}
+			}
+		};
 	}
 }

--- a/src/main/java/com/forrestgof/jobscanner/common/config/properties/AwsProperties.java
+++ b/src/main/java/com/forrestgof/jobscanner/common/config/properties/AwsProperties.java
@@ -1,0 +1,28 @@
+package com.forrestgof.jobscanner.common.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+@ConstructorBinding
+@ConfigurationProperties(prefix = "aws")
+public record AwsProperties(
+	Cloudwatch cloudwatch,
+	Loadbalancer loadbalancer
+) {
+
+	public record Cloudwatch(
+		Credentials credentials
+	) {
+
+		public record Credentials(
+			String accessKey,
+			String secretKey
+		) {
+		}
+	}
+
+	public record Loadbalancer(
+		String healthCheckPath
+	) {
+	}
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -17,6 +17,21 @@
         </layout>
     </appender>
 
+    <appender name="aws_cloud_watch_console" class="ca.pjer.logback.AwsLogsAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>${LOG_PATTERN}</Pattern>
+        </layout>
+        <logGroupName>jobscanner-console</logGroupName>
+        <logStreamUuidPrefix>jobscanner-console-</logStreamUuidPrefix>
+        <logRegion>ap-northeast-2</logRegion>
+        <maxBatchLogEvents>10</maxBatchLogEvents>
+        <maxFlushTimeMillis>30000</maxFlushTimeMillis>
+        <maxBlockTimeMillis>5000</maxBlockTimeMillis>
+        <retentionTimeDays>0</retentionTimeDays>
+        <accessKeyId>${AWS_ACCESS_KEY}</accessKeyId>
+        <secretAccessKey>${AWS_SECRET_KEY}</secretAccessKey>
+    </appender>
+
     <appender name="aws_cloud_watch_log" class="ca.pjer.logback.AwsLogsAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>INFO</level>
@@ -62,6 +77,7 @@
     <springProfile name="default">
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="aws_cloud_watch_console"/>
             <appender-ref ref="aws_cloud_watch_log"/>
             <appender-ref ref="aws_cloud_watch_error"/>
         </root>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -18,6 +18,9 @@
     </appender>
 
     <appender name="aws_cloud_watch_log" class="ca.pjer.logback.AwsLogsAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
         <layout>
             <pattern>[%thread] [%level] [%file:%line] - %msg%n</pattern>
         </layout>


### PR DESCRIPTION
[주의사항]
- .yml 파일 업데이트 했습니다.

[문제] 
- 알 수 없는 request 로그가 계속 찍히는 문제가 있었습니다.

[원인] 
- 로드밸런서의 Health Check였습니다.

[해결] 
- AwsProperties를 생성해서 Health Check의 URI를 LoggingFillter에 주입하고, Health Check요청일 경우에는 HTTP request, response log를 남기지 않게 설정했습니다.
- Spring Health Check 레퍼런스를 찾아보고 spring-boot-starter-actuator 의존성을 추가했습니다.
- spring-boot-starter-actuator 의존성 추가하고 /actuator/health로 health check해보기 위해서는 SwaggerConfig에 @Bean을 추가해서 의존성 문제를 해결해야 했습니다.
- [참고 링크](https://github.com/springfox/springfox/issues/3462)

[배포 이후 할 것] 
- 로드밸런서 Health Check URL를 /actuator/health로 바꿔줘야합니다.